### PR TITLE
Update GitHub Classroom workflow for visible scores

### DIFF
--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -1,11 +1,8 @@
-name: GitHub Classroom Workflow
+name: Autograding Tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch:
+  - push
+  - repository_dispatch
 
 permissions:
   checks: write
@@ -13,12 +10,63 @@ permissions:
   contents: read
 
 jobs:
-  autograding:
+  run-autograding-tests:
     runs-on: ubuntu-latest
     if: github.actor != 'github-classroom[bot]'
     steps:
-      - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-      - name: Run Autograding
-        uses: education/autograding@v1
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc make libc6-dev
+
+    - name: Test 1 - Compilation Check
+      id: test-compilation
+      uses: classroom-resources/autograding-io-grader@v1
+      with:
+        test-name: Test 1 - Compilation Check
+        setup-command: ''
+        command: make clean && make all
+        input: ''
+        expected-output: '✓ all day 1 programs compiled successfully!'
+        comparison-method: included
+        timeout: 10
+        max-score: 33
+
+    - name: Test 2 - Voltage Validation
+      id: test-voltage
+      uses: classroom-resources/autograding-io-grader@v1
+      with:
+        test-name: Test 2 - Voltage Validation
+        setup-command: 'sudo apt-get update && sudo apt-get install -y gcc make libc6-dev && make clean && make all'
+        command: ./tests/test_voltage
+        input: ''
+        expected-output: '✓ all tests passed!'
+        comparison-method: included
+        timeout: 10
+        max-score: 33
+
+    - name: Test 3 - Power Calculation
+      id: test-power
+      uses: classroom-resources/autograding-io-grader@v1
+      with:
+        test-name: Test 3 - Power Calculation
+        setup-command: 'sudo apt-get update && sudo apt-get install -y gcc make libc6-dev && make clean && make all'
+        command: ./tests/test_power
+        input: ''
+        expected-output: '✓ all tests passed!'
+        comparison-method: included
+        timeout: 10
+        max-score: 34
+
+    - name: Autograding Reporter
+      uses: classroom-resources/autograding-grading-reporter@v1
+      env:
+        TEST-COMPILATION_RESULTS: "${{steps.test-compilation.outputs.result}}"
+        TEST-VOLTAGE_RESULTS: "${{steps.test-voltage.outputs.result}}"
+        TEST-POWER_RESULTS: "${{steps.test-power.outputs.result}}"
+      with:
+        runners: test-compilation,test-voltage,test-power
 


### PR DESCRIPTION
## Summary
- Updated the autograding workflow to use `classroom-resources/autograding-io-grader@v1` and `autograding-grading-reporter@v1` actions, matching the working example pattern
- This fixes the issue where scores were not appearing in the GitHub Classroom dashboard by properly integrating individual test steps and reporting

## Test plan
- [ ] Verify workflow runs on push to a test repo
- [ ] Check that scores appear in GitHub Classroom for compilation (33 pts), voltage (33 pts), and power (34 pts) tests
- [ ] Confirm no syntax errors in Actions tab